### PR TITLE
Improve source content relocation FQN matching

### DIFF
--- a/src/it/projects/reloc-source-content-with-fqn/impl/pom.xml
+++ b/src/it/projects/reloc-source-content-with-fqn/impl/pom.xml
@@ -1,0 +1,32 @@
+<?xml version="1.0" encoding="UTF-8"?>
+
+<!--
+Licensed to the Apache Software Foundation (ASF) under one
+or more contributor license agreements.  See the NOTICE file
+distributed with this work for additional information
+regarding copyright ownership.  The ASF licenses this file
+to you under the Apache License, Version 2.0 (the
+"License"); you may not use this file except in compliance
+with the License.  You may obtain a copy of the License at
+
+  http://www.apache.org/licenses/LICENSE-2.0
+
+Unless required by applicable law or agreed to in writing,
+software distributed under the License is distributed on an
+"AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+KIND, either express or implied.  See the License for the
+specific language governing permissions and limitations
+under the License.
+-->
+
+<project xmlns="http://maven.apache.org/POM/4.0.0"
+         xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance"
+         xsi:schemaLocation="http://maven.apache.org/POM/4.0.0 http://maven.apache.org/xsd/maven-4.0.0.xsd">
+    <modelVersion>4.0.0</modelVersion>
+    <parent>
+        <groupId>org.apache.maven.its.shade.rscwf</groupId>
+        <artifactId>test-parent</artifactId>
+        <version>1.0</version>
+    </parent>
+    <artifactId>test-impl</artifactId>
+</project>

--- a/src/it/projects/reloc-source-content-with-fqn/impl/src/main/java/Main.java
+++ b/src/it/projects/reloc-source-content-with-fqn/impl/src/main/java/Main.java
@@ -1,0 +1,66 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one
+ * or more contributor license agreements.  See the NOTICE file
+ * distributed with this work for additional information
+ * regarding copyright ownership.  The ASF licenses this file
+ * to you under the Apache License, Version 2.0 (the
+ * "License"); you may not use this file except in compliance
+ * with the License.  You may obtain a copy of the License at
+ *
+ *   http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing,
+ * software distributed under the License is distributed on an
+ * "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+ * KIND, either express or implied.  See the License for the
+ * specific language governing permissions and limitations
+ * under the License.
+ */
+
+import java.util.List;
+
+public class Main
+{
+    public static relocated.StringMessage getStringMessage( CharSequence s )
+    {
+        relocated.StringMessage msg;
+        if (s instanceof String)
+        {
+            msg = new relocated.StringMessage( (String) s );
+        }
+        else if (s == null) {
+            msg = relocated.StringMessage.EMPTY;
+        }
+        else
+        {
+            msg = relocated.StringMessage
+                    .from( s );
+        }
+        return msg;
+    }
+
+    public static relocated.StringMessage[] toStringMessageArray( List<relocated.Message> messages )
+    {
+        return messages.stream()
+                .map( m ->
+                {
+                    if (m instanceof relocated.StringMessage)
+                    {
+                        return (relocated.StringMessage) m;
+                    }
+                    else
+                    {
+                        return getStringMessage( m.asString() );
+                    }
+                } ).toArray( relocated.StringMessage[]::new );
+    }
+
+
+    public static class MyMessage extends relocated.StringMessage implements relocated.Message
+    {
+        public MyMessage( String s ) throws relocated.MessageException
+        {
+            super(s);
+        }
+    }
+}

--- a/src/it/projects/reloc-source-content-with-fqn/impl/src/main/java/relocated/Message.java
+++ b/src/it/projects/reloc-source-content-with-fqn/impl/src/main/java/relocated/Message.java
@@ -1,0 +1,25 @@
+package relocated;
+
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one
+ * or more contributor license agreements.  See the NOTICE file
+ * distributed with this work for additional information
+ * regarding copyright ownership.  The ASF licenses this file
+ * to you under the Apache License, Version 2.0 (the
+ * "License"); you may not use this file except in compliance
+ * with the License.  You may obtain a copy of the License at
+ *
+ *   http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing,
+ * software distributed under the License is distributed on an
+ * "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+ * KIND, either express or implied.  See the License for the
+ * specific language governing permissions and limitations
+ * under the License.
+ */
+
+public interface Message
+{
+    String asString();
+}

--- a/src/it/projects/reloc-source-content-with-fqn/impl/src/main/java/relocated/MessageException.java
+++ b/src/it/projects/reloc-source-content-with-fqn/impl/src/main/java/relocated/MessageException.java
@@ -1,0 +1,24 @@
+package relocated;
+
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one
+ * or more contributor license agreements.  See the NOTICE file
+ * distributed with this work for additional information
+ * regarding copyright ownership.  The ASF licenses this file
+ * to you under the Apache License, Version 2.0 (the
+ * "License"); you may not use this file except in compliance
+ * with the License.  You may obtain a copy of the License at
+ *
+ *   http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing,
+ * software distributed under the License is distributed on an
+ * "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+ * KIND, either express or implied.  See the License for the
+ * specific language governing permissions and limitations
+ * under the License.
+ */
+
+public class MessageException extends Exception
+{
+}

--- a/src/it/projects/reloc-source-content-with-fqn/impl/src/main/java/relocated/StringMessage.java
+++ b/src/it/projects/reloc-source-content-with-fqn/impl/src/main/java/relocated/StringMessage.java
@@ -1,0 +1,45 @@
+package relocated;
+
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one
+ * or more contributor license agreements.  See the NOTICE file
+ * distributed with this work for additional information
+ * regarding copyright ownership.  The ASF licenses this file
+ * to you under the Apache License, Version 2.0 (the
+ * "License"); you may not use this file except in compliance
+ * with the License.  You may obtain a copy of the License at
+ *
+ *   http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing,
+ * software distributed under the License is distributed on an
+ * "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+ * KIND, either express or implied.  See the License for the
+ * specific language governing permissions and limitations
+ * under the License.
+ */
+
+import java.util.Objects;
+
+public class StringMessage implements Message
+{
+    public static final StringMessage EMPTY = new StringMessage("");
+
+    private final String value;
+
+    public StringMessage( String value )
+    {
+        this.value = Objects.requireNonNull( value );
+    }
+
+    public static StringMessage from( CharSequence s )
+    {
+        return s.length() == 0 ? EMPTY : new StringMessage( s.toString() );
+    }
+
+    @Override
+    public String asString() {
+        return value;
+    }
+
+}

--- a/src/it/projects/reloc-source-content-with-fqn/pom.xml
+++ b/src/it/projects/reloc-source-content-with-fqn/pom.xml
@@ -1,0 +1,57 @@
+<?xml version="1.0" encoding="UTF-8"?>
+
+<!--
+Licensed to the Apache Software Foundation (ASF) under one
+or more contributor license agreements.  See the NOTICE file
+distributed with this work for additional information
+regarding copyright ownership.  The ASF licenses this file
+to you under the Apache License, Version 2.0 (the
+"License"); you may not use this file except in compliance
+with the License.  You may obtain a copy of the License at
+
+  http://www.apache.org/licenses/LICENSE-2.0
+
+Unless required by applicable law or agreed to in writing,
+software distributed under the License is distributed on an
+"AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+KIND, either express or implied.  See the License for the
+specific language governing permissions and limitations
+under the License.
+-->
+
+<project xmlns="http://maven.apache.org/POM/4.0.0"
+         xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance"
+         xsi:schemaLocation="http://maven.apache.org/POM/4.0.0 http://maven.apache.org/xsd/maven-4.0.0.xsd">
+    <modelVersion>4.0.0</modelVersion>
+    <groupId>org.apache.maven.its.shade.rscwf</groupId>
+    <artifactId>test-parent</artifactId>
+    <packaging>pom</packaging>
+    <version>1.0</version>
+    <modules>
+        <module>impl</module>
+        <module>uber</module>
+    </modules>
+    <dependencyManagement>
+        <dependencies>
+            <dependency>
+                <groupId>org.apache.maven.its.shade.rscwf</groupId>
+                <artifactId>test-impl</artifactId>
+                <version>1.0</version>
+            </dependency>
+        </dependencies>
+    </dependencyManagement>
+    <build>
+        <plugins>
+            <plugin>
+                <artifactId>maven-source-plugin</artifactId>
+                <executions>
+                    <execution>
+                        <goals>
+                            <goal>jar-no-fork</goal>
+                        </goals>
+                    </execution>
+                </executions>
+            </plugin>
+        </plugins>
+    </build>
+</project>

--- a/src/it/projects/reloc-source-content-with-fqn/uber/pom.xml
+++ b/src/it/projects/reloc-source-content-with-fqn/uber/pom.xml
@@ -1,0 +1,63 @@
+<?xml version="1.0" encoding="UTF-8"?>
+
+<!--
+Licensed to the Apache Software Foundation (ASF) under one
+or more contributor license agreements.  See the NOTICE file
+distributed with this work for additional information
+regarding copyright ownership.  The ASF licenses this file
+to you under the Apache License, Version 2.0 (the
+"License"); you may not use this file except in compliance
+with the License.  You may obtain a copy of the License at
+
+  http://www.apache.org/licenses/LICENSE-2.0
+
+Unless required by applicable law or agreed to in writing,
+software distributed under the License is distributed on an
+"AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+KIND, either express or implied.  See the License for the
+specific language governing permissions and limitations
+under the License.
+-->
+
+<project xmlns="http://maven.apache.org/POM/4.0.0"
+         xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance"
+         xsi:schemaLocation="http://maven.apache.org/POM/4.0.0 http://maven.apache.org/xsd/maven-4.0.0.xsd">
+    <modelVersion>4.0.0</modelVersion>
+    <parent>
+        <groupId>org.apache.maven.its.shade.rscwf</groupId>
+        <artifactId>test-parent</artifactId>
+        <version>1.0</version>
+    </parent>
+    <artifactId>test-uber</artifactId>
+    <dependencies>
+        <dependency>
+            <groupId>org.apache.maven.its.shade.rscwf</groupId>
+            <artifactId>test-impl</artifactId>
+        </dependency>
+    </dependencies>
+    <build>
+        <plugins>
+            <plugin>
+                <artifactId>maven-shade-plugin</artifactId>
+                <version>@project.version@</version>
+                <executions>
+                    <execution>
+                        <goals>
+                            <goal>shade</goal>
+                        </goals>
+                        <configuration>
+                            <createSourcesJar>true</createSourcesJar>
+                            <shadeSourcesContent>true</shadeSourcesContent>
+                            <relocations>
+                                <relocation>
+                                    <pattern>relocated</pattern>
+                                    <shadedPattern>hidden</shadedPattern>
+                                </relocation>
+                            </relocations>
+                        </configuration>
+                    </execution>
+                </executions>
+            </plugin>
+        </plugins>
+    </build>
+</project>

--- a/src/it/projects/reloc-source-content-with-fqn/verify.groovy
+++ b/src/it/projects/reloc-source-content-with-fqn/verify.groovy
@@ -1,0 +1,39 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one
+ * or more contributor license agreements.  See the NOTICE file
+ * distributed with this work for additional information
+ * regarding copyright ownership.  The ASF licenses this file
+ * to you under the Apache License, Version 2.0 (the
+ * "License"); you may not use this file except in compliance
+ * with the License.  You may obtain a copy of the License at
+ *
+ *   http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing,
+ * software distributed under the License is distributed on an
+ * "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+ * KIND, either express or implied.  See the License for the
+ * specific language governing permissions and limitations
+ * under the License.
+ */
+
+def sourceJarFile = new java.util.jar.JarFile( new File( basedir, "uber/target/test-uber-1.0-sources.jar" ) )
+try
+{
+    assert null != sourceJarFile.getJarEntry( "hidden/Message.java" )
+    assert null != sourceJarFile.getJarEntry( "hidden/MessageException.java" )
+    assert null != sourceJarFile.getJarEntry( "hidden/StringMessage.java" )
+    assert null != sourceJarFile.getJarEntry( "Main.java" )
+
+    def is = sourceJarFile.getInputStream(sourceJarFile.getJarEntry( "Main.java" ))
+
+    def content = is.text;
+    assert false == content.contains( 'relocated.');
+    assert content.contains( 'hidden.Message');
+    assert content.contains( 'hidden.MessageException');
+    assert content.contains( 'hidden.StringMessage');
+}
+finally
+{
+    sourceJarFile.close()
+}


### PR DESCRIPTION
Fixing problem where source content relocation doesn't replace all instances of fully-qualified class names.
